### PR TITLE
Possibility to override config.sh values

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ mode
 app_config
 *.sublime-*
 last_update_at
+config-override.sh
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 > Any trouble, please visit: https://github.com/diogocavilha/fancy-git#troubleshooting-pick
 
+### v6.2.12
+
+- Add possibility to override standard configuration via config-override.sh
+
 ### v6.2.11
 
 - Evaluate remote of current branch instead of using hardcoded origin in themes.

--- a/README.md
+++ b/README.md
@@ -201,6 +201,17 @@ Basically, most of the Fancy Git aliases work this way.
 | gu \<file\> [<other_file>] | git reset HEAD \<file\>                                                                                                                                | Remove files from staging area.
 | pve                       | [file](https://github.com/diogocavilha/fancy-git/blob/master/alias_functions/pve.sh)                                                                  | Show the current Python virtual environment name.
 
+## Advanced tweaking - override values from config.sh
+
+If you like to tweak things more in-depth, like color values, special characters and such, you can create a new file `~/.fancy-git/config-override.sh`. This file is sourced after reading the standard configuration, so that you can override any variable found in the main `config.sh`.
+
+Example:
+You want to change the branch icon, because you are using a different console font and the icon is on a different character position inside the font. Simply create the override file and add a line like this (for sure, you will likely have changed the symbol):
+
+```sh
+branch_icon=""
+```
+
 ## Troubleshooting :pick:
 
 ### Problems with Konsole Terminal

--- a/commands.sh
+++ b/commands.sh
@@ -115,7 +115,7 @@ fg_update_checker() {
 
     if [ "$updates" != "" ]; then
         echo -e "\n Hey! A new Fancy Git update has been released!"
-        read -p " Would you like to update it? [Y/n]: " option
+        read -t 5 -p " Would you like to update it? [Y/n]: " option
         echo ""
 
         case "$option" in

--- a/config.sh
+++ b/config.sh
@@ -174,3 +174,9 @@ s_darkgray01="${dark_gray_01}${separator}${none}"
 s_darkgray01_bgdarkgray="${dark_gray_01}${bg_dark_gray}${separator}${bg_none}${none}"
 s_darkgray01_bgdarkgray05="${dark_gray_01}${bg_dark_gray_05}${separator}${bg_none}${none}"
 s_darkgray05_bgdarkgray04="${dark_gray_05}${bg_dark_gray_04}${separator}${bg_none}${none}"
+
+# include config-override.inc
+if [ -e ~/.fancy-git/config-override.sh ]; then
+    . ~/.fancy-git/config-override.sh
+fi
+

--- a/version.sh
+++ b/version.sh
@@ -3,4 +3,4 @@
 # Author: Diogo Alexsander Cavilha <diogocavilha@gmail.com>
 # Date:   11.17.2017
 
-FANCYGIT_VERSION="6.2.11"
+FANCYGIT_VERSION="6.2.12"


### PR DESCRIPTION
Hi!

### What?
This modification adds the possibility to override `config.sh` values without modifying default values directly.

### Why?
As I am using a custom patched font from [nerd-fonts](https://github.com/ryanoasis/nerd-fonts) where the special characters for seperator, branch icon, etc. are in a different position, I was looking for a way to securely override the values inside `config.sh` without interfering with the default config. Now fancy-git can update itself safely without me having to modify `config.sh` over and over again.

### And why like this?
I included this as a separate override file and not as a new "fancygit config" possibility because I thought, it is an advanced feature that is only needed in some special, rather rare cases and therefor the cleaner and easier solution.

Regards,
Holger