### PR TITLE
Adding Conda virtual env variable to prompts

### DIFF
--- a/prompt_styles/dark-col-double-line.sh
+++ b/prompt_styles/dark-col-double-line.sh
@@ -94,7 +94,7 @@ fancygit_prompt_builder() {
 
     prompt_symbol="\n${user_symbol}\$${user_symbol_end}"
 
-    if ! [ -z ${VIRTUAL_ENV} ]
+    if ! [ -z ${VIRTUAL_ENV} ] || ([ ${CONDA_DEFAULT_ENV} != "base" ] && ! [ -z ${CONDA_DEFAULT_ENV} ])
     then
         venv="$working_on_venv"
     fi

--- a/prompt_styles/dark-double-line.sh
+++ b/prompt_styles/dark-double-line.sh
@@ -75,7 +75,7 @@ fancygit_prompt_builder() {
 
     prompt_symbol="\n${user_symbol}\$${user_symbol_end}"
 
-    if ! [ -z ${VIRTUAL_ENV} ]
+    if ! [ -z ${VIRTUAL_ENV} ] || ([ ${CONDA_DEFAULT_ENV} != "base" ] && ! [ -z ${CONDA_DEFAULT_ENV} ])
     then
         venv="$working_on_venv"
     fi

--- a/prompt_styles/dark.sh
+++ b/prompt_styles/dark.sh
@@ -73,7 +73,7 @@ fancygit_prompt_builder() {
 
     prompt_symbol="${user_symbol} \$ ${user_symbol_end}"
 
-    if ! [ -z ${VIRTUAL_ENV} ]
+    if ! [ -z ${VIRTUAL_ENV} ] || ([ ${CONDA_DEFAULT_ENV} != "base" ] && ! [ -z ${CONDA_DEFAULT_ENV} ])
     then
         venv="$working_on_venv"
     fi

--- a/prompt_styles/default.sh
+++ b/prompt_styles/default.sh
@@ -73,7 +73,7 @@ fancygit_prompt_builder() {
 
     prompt_symbol="${user_symbol} \$ ${user_symbol_end}"
 
-    if ! [ -z ${VIRTUAL_ENV} ]
+    if ! [ -z ${VIRTUAL_ENV} ] || ([ ${CONDA_DEFAULT_ENV} != "base" ] && ! [ -z ${CONDA_DEFAULT_ENV} ])
     then
         venv="$working_on_venv"
     fi

--- a/prompt_styles/fancy-double-line.sh
+++ b/prompt_styles/fancy-double-line.sh
@@ -73,7 +73,7 @@ fancygit_prompt_builder() {
 
     prompt_symbol="\n${user_symbol}\$${user_symbol_end}"
 
-    if ! [ -z ${VIRTUAL_ENV} ]
+    if ! [ -z ${VIRTUAL_ENV} ] || ([ ${CONDA_DEFAULT_ENV} != "base" ] && ! [ -z ${CONDA_DEFAULT_ENV} ])
     then
         venv="$working_on_venv"
     fi

--- a/prompt_styles/human-dark-single-line.sh
+++ b/prompt_styles/human-dark-single-line.sh
@@ -42,6 +42,10 @@ fancygit_prompt_builder() {
         venv="`basename \"$VIRTUAL_ENV\"` ${venvfor} "
     fi
 
+    if ([ ${CONDA_DEFAULT_ENV} != "base" ] && ! [ -z ${CONDA_DEFAULT_ENV} ]); then
+        venv="`basename \"$CONDA_DEFAULT_ENV\"` ${venvfor} "
+    fi
+
     if [ "$branch_name" != "" ]; then
         branch_name=" ${red}on${none} ${orange}$branch_name${none}"
     fi

--- a/prompt_styles/human-dark.sh
+++ b/prompt_styles/human-dark.sh
@@ -42,6 +42,10 @@ fancygit_prompt_builder() {
         venv="`basename \"$VIRTUAL_ENV\"` ${venvfor} "
     fi
 
+    if ([ ${CONDA_DEFAULT_ENV} != "base" ] && ! [ -z ${CONDA_DEFAULT_ENV} ]); then
+        venv="`basename \"$CONDA_DEFAULT_ENV\"` ${venvfor} "
+    fi
+
     if [ "$branch_name" != "" ]; then
         branch_name="${on} ${orange}$branch_name${none}"
     fi

--- a/prompt_styles/human-single-line.sh
+++ b/prompt_styles/human-single-line.sh
@@ -39,6 +39,10 @@ fancygit_prompt_builder() {
         venv="${light_yellow}`basename \"$VIRTUAL_ENV\"`${none} for "
     fi
 
+    if ([ ${CONDA_DEFAULT_ENV} != "base" ] && ! [ -z ${CONDA_DEFAULT_ENV} ]); then
+        venv="${light_yellow}`basename \"$CONDA_DEFAULT_ENV\"`${none} for "
+    fi
+
     if [ "$branch_name" != "" ]; then
         branch_name=" on ${light_magenta}$branch_name${none}"
     fi

--- a/prompt_styles/human.sh
+++ b/prompt_styles/human.sh
@@ -39,6 +39,10 @@ fancygit_prompt_builder() {
         venv="${light_yellow}`basename \"$VIRTUAL_ENV\"`${none} for "
     fi
 
+    if ([ ${CONDA_DEFAULT_ENV} != "base" ] && ! [ -z ${CONDA_DEFAULT_ENV} ]); then
+        venv="${light_yellow}`basename \"$CONDA_DEFAULT_ENV\"`${none} for "
+    fi
+
     if [ "$branch_name" != "" ]; then
         branch_name="on ${light_magenta}$branch_name${none}"
     fi

--- a/prompt_styles/light-double-line.sh
+++ b/prompt_styles/light-double-line.sh
@@ -73,7 +73,7 @@ fancygit_prompt_builder() {
 
     prompt_symbol="\n${user_symbol}\$${user_symbol_end}"
 
-    if ! [ -z ${VIRTUAL_ENV} ]
+    if ! [ -z ${VIRTUAL_ENV} ] || ([ ${CONDA_DEFAULT_ENV} != "base" ] && ! [ -z ${CONDA_DEFAULT_ENV} ])
     then
         venv="$working_on_venv"
     fi

--- a/prompt_styles/light.sh
+++ b/prompt_styles/light.sh
@@ -73,7 +73,7 @@ fancygit_prompt_builder() {
 
     prompt_symbol="${user_symbol} \$ ${user_symbol_end}"
 
-    if ! [ -z ${VIRTUAL_ENV} ]
+    if ! [ -z ${VIRTUAL_ENV} ] || ([ ${CONDA_DEFAULT_ENV} != "base" ] && ! [ -z ${CONDA_DEFAULT_ENV} ])
     then
         venv="$working_on_venv"
     fi

--- a/prompt_styles/simple-double-line.sh
+++ b/prompt_styles/simple-double-line.sh
@@ -45,6 +45,10 @@ fancygit_prompt_builder() {
         venv="(`basename \"$VIRTUAL_ENV\"`) "
     fi
 
+    if ([ ${CONDA_DEFAULT_ENV} != "base" ] && ! [ -z ${CONDA_DEFAULT_ENV} ]); then
+        venv="(`basename \"$CONDA_DEFAULT_ENV\"`) "
+    fi
+
     if fg_show_user_at_machine
     then
         user_at_host="$user$at$host:"

--- a/prompt_styles/simple.sh
+++ b/prompt_styles/simple.sh
@@ -50,6 +50,10 @@ fancygit_prompt_builder() {
         venv="(`basename \"$VIRTUAL_ENV\"`) "
     fi
 
+    if ([ ${CONDA_DEFAULT_ENV} != "base" ] && ! [ -z ${CONDA_DEFAULT_ENV} ]); then
+        venv="(`basename \"$CONDA_DEFAULT_ENV\"`) "
+    fi
+
     if fg_show_user_at_machine
     then
         user_at_host="$user$at$host:"


### PR DESCRIPTION
Conda uses $CONDA_DEFAULT_ENV to denote the virtual environment. The default value/environment is "base". Added logic to check for a $CONDA_DEFAULT_ENV value, and if one exists, check that it is not base. If passes, then follow the same prompt logic as previous $VIRTUAL_ENV feature.