### PR TITLE
Add prompt time

### DIFF
--- a/app_config_sample
+++ b/app_config_sample
@@ -1,4 +1,5 @@
 style:default
 show-full-path:true
 show-user-at-machine:true
+show-time:true
 fresh_file

--- a/commands.sh
+++ b/commands.sh
@@ -86,6 +86,18 @@ fg_show_full_path() {
     return 0
 }
 
+fg_show_time() {
+    local config_content=""
+
+    config_content=$(grep -o 'show-time:false' < ~/.fancy-git/app_config)
+
+    if [ "$config_content" = "show-time:false" ]; then
+        return 1
+    fi
+
+    return 0
+}
+
 fg_show_user_at_machine() {
     local config_content=""
 
@@ -200,6 +212,8 @@ case "$1" in
     "--disable-full-path") fg_update_app_config "show-full-path" "false";;
     "--enable-show-user-at-machine") fg_update_app_config "show-user-at-machine" "true";;
     "--disable-show-user-at-machine") fg_update_app_config "show-user-at-machine" "false";;
+    "--enable-show-time") fg_update_app_config "show-time" "true";;
+    "--disable-show-time") fg_update_app_config "show-time" "false";;
     "--config-list") fg_show_app_config;;
     "--config-reset") fg_reset_app_config;;
     "update") fancygit_update;;

--- a/config.sh
+++ b/config.sh
@@ -182,6 +182,10 @@ s_darkgray01_bgdarkgray="${dark_gray_01}${bg_dark_gray}${separator}${bg_none}${n
 s_darkgray01_bgdarkgray05="${dark_gray_01}${bg_dark_gray_05}${separator}${bg_none}${none}"
 s_darkgray05_bgdarkgray04="${dark_gray_05}${bg_dark_gray_04}${separator}${bg_none}${none}"
 
+# Time
+
+time_format="%H:%M:%S"
+
 # include config-override.inc
 if [ -e ~/.fancy-git/config-override.sh ]; then
     . ~/.fancy-git/config-override.sh

--- a/fancygit-completion
+++ b/fancygit-completion
@@ -28,6 +28,8 @@ _fancygit() {
         --disable-full-path \
         --enable-show-user-at-machine \
         --disable-show-user-at-machine \
+        --enable-show-time \
+        --disable-show-time \
         --config-list \
         --config-reset
     '

--- a/help.sh
+++ b/help.sh
@@ -22,6 +22,8 @@ echo " Fancy Git v$FANCYGIT_VERSION - $fg_current_year by Diogo Alexsander Cavil
  fancygit --colors-set          Apply the color scheme.
  fancygit --full-path-disable   Fancygit will show only the the directory name you are working on. Not the entire path.
  fancygit --full-path-enable    Fancygit will show the entire path.
+ fancygit --enable-show-time    Fancygit will show current time
+ fancygit --disable-show-time   Fancygit will not show current time
  fancygit --config-list         Show fancygit config.
  fancygit --config-reset        Show fancygit config.
 

--- a/prompt_styles/dark-col-double-line.sh
+++ b/prompt_styles/dark-col-double-line.sh
@@ -35,9 +35,12 @@ fancygit_prompt_builder() {
     path_end="${none}${bold_none}"
     branch="${s_darkgray05_bgdarkgray04}${bg_dark_gray_04}${white}${bold}"
     branch_end="${bg_none}${none}${bold_none}${s_darkgray04}"
+    time="${orange}${bg_dark_gray_01}${bold}"
+    time_end="${bold_none}${bg_none}"
     local venv=""
     local path_sign=""
     local user_at_host=""
+    local prompt_time=""
 
     # Building prompt
     if [ "$branch_status" != "" ]
@@ -78,6 +81,12 @@ fancygit_prompt_builder() {
         has_unpushed_commits=""
     fi
 
+    if fg_show_time
+    then
+      formatted_time=$(date +"${time_format}")
+      prompt_time="${time}[${formatted_time}] ${time_end}"
+    fi
+
     if fg_show_user_at_machine
     then
         user_at_host="${user}\\u${at}@${host}\\h "
@@ -112,11 +121,11 @@ fancygit_prompt_builder() {
         branch_icon=$(fg_get_branch_icon)
         prompt_path="${path_git}${venv}${has_git_stash}${has_untracked_files}${has_changed_files}${has_added_files}${has_unpushed_commits} $path_sign ${path_end}"
         prompt_branch="${branch} ${branch_icon} ${branch_name} ${branch_end}"
-        PS1="${prompt_user}${prompt_path}${prompt_branch}${prompt_symbol} "
+        PS1="${prompt_time}${prompt_user}${prompt_path}${prompt_branch}${prompt_symbol} "
         return
     fi
 
-    PS1="${prompt_user}${prompt_path}${prompt_symbol} "
+    PS1="${prompt_time}${prompt_user}${prompt_path}${prompt_symbol} "
 }
 
 PROMPT_COMMAND="fancygit_prompt_builder"

--- a/prompt_styles/dark-double-line.sh
+++ b/prompt_styles/dark-double-line.sh
@@ -23,9 +23,12 @@ fancygit_prompt_builder() {
     path_end="${none}${bold_none}"
     branch="${s_darkgray_bgwhite}${bg_white}${black}${bold}"
     branch_end="${bg_none}${none}${bold_none}${s_white}"
+    time="${white}${bg_dark_gray_01}${bold}"
+    time_end="${bold_none}${bg_none}"
     local venv=""
     local path_sign=""
     local prompt_user=""
+    local prompt_time=""
 
     # Building prompt
     if [ "$branch_status" != "" ]
@@ -66,6 +69,12 @@ fancygit_prompt_builder() {
         has_unpushed_commits=""
     fi
 
+    if fg_show_time
+    then
+      formatted_time=$(date +"${time_format}")
+      prompt_time="${time}[${formatted_time}] ${time_end}"
+    fi
+
     if fg_show_user_at_machine
     then
         user_at_host="${white}${bg_dark_gray_01}${bold}"
@@ -93,11 +102,11 @@ fancygit_prompt_builder() {
         branch_icon=$(fg_get_branch_icon)
         prompt_path="${path_git}${venv}${has_git_stash}${has_untracked_files}${has_changed_files}${has_added_files}${has_unpushed_commits} $path_sign ${path_end}"
         prompt_branch="${branch} ${branch_icon} ${branch_name} ${branch_end}"
-        PS1="${prompt_user}${prompt_path}${prompt_branch}${prompt_symbol} "
+        PS1="${prompt_time}${prompt_user}${prompt_path}${prompt_branch}${prompt_symbol} "
         return
     fi
 
-    PS1="${prompt_user}${prompt_path}${prompt_symbol} "
+    PS1="${prompt_time}${prompt_user}${prompt_path}${prompt_symbol} "
 }
 
 PROMPT_COMMAND="fancygit_prompt_builder"

--- a/prompt_styles/dark.sh
+++ b/prompt_styles/dark.sh
@@ -23,6 +23,8 @@ fancygit_prompt_builder() {
     path_end="${none}${bold_none}"
     branch="${s_darkgray01_bgwhite}${bg_white}${black}${bold}"
     branch_end="${bg_none}${none}${bold_none}${s_white}"
+    time="${white}${bg_dark_gray_01}${bold}"
+    time_end="${bold_none}${bg_none}"
     local venv=""
     local path_sign=""
     local prompt_user=""
@@ -66,6 +68,12 @@ fancygit_prompt_builder() {
         has_unpushed_commits=""
     fi
 
+    if fg_show_time
+    then
+      formatted_time=$(date +"${time_format}")
+      prompt_time="${time}[${formatted_time}] ${time_end}"
+    fi
+
     if fg_show_user_at_machine
     then
         prompt_user="${user_at_host}\\u@\\h ${user_at_host_end}"
@@ -91,11 +99,11 @@ fancygit_prompt_builder() {
         branch_icon=$(fg_get_branch_icon)
         prompt_path="${path_git}${venv}${has_git_stash}${has_untracked_files}${has_changed_files}${has_added_files}${has_unpushed_commits} $path_sign ${path_end}"
         prompt_branch="${branch} ${branch_icon} ${branch_name} ${branch_end}"
-        PS1="${prompt_user}${prompt_symbol}${prompt_path}${prompt_branch} "
+        PS1="${prompt_time}${prompt_user}${prompt_symbol}${prompt_path}${prompt_branch} "
         return
     fi
 
-    PS1="${prompt_user}${prompt_symbol}${prompt_path} "
+    PS1="${prompt_time}${prompt_user}${prompt_symbol}${prompt_path} "
 }
 
 PROMPT_COMMAND="fancygit_prompt_builder"

--- a/prompt_styles/default.sh
+++ b/prompt_styles/default.sh
@@ -23,9 +23,12 @@ fancygit_prompt_builder() {
     user_symbol_end="${none}${bold_none}${bg_none}${s_lightmagenta_bgblue}"
     branch="${s_blue_bgwhite}${bg_white}${black}${bold}"
     branch_end="${bg_none}${none}${bold_none}${s_white}"
+    time="${white}${bg_dark_gray}${bold}"
+    time_end="${bold_none}${bg_none}"
     local venv=""
     local path_sign=""
     local prompt_user=""
+    local prompt_time=""
 
     # Building prompt
     if [ "$branch_status" != "" ]
@@ -66,6 +69,12 @@ fancygit_prompt_builder() {
         has_unpushed_commits=""
     fi
 
+    if fg_show_time
+    then
+      formatted_time=$(date +"${time_format}")
+      prompt_time="${time}[${formatted_time}] ${time_end}"
+    fi
+
     if fg_show_user_at_machine
     then
         prompt_user="${user_at_host}\\u@\\h ${user_at_host_end}"
@@ -91,11 +100,11 @@ fancygit_prompt_builder() {
         branch_icon=$(fg_get_branch_icon)
         prompt_path="${path_git}${venv}${has_git_stash}${has_untracked_files}${has_changed_files}${has_added_files}${has_unpushed_commits} $path_sign ${path_end}"
         prompt_branch="${branch} ${branch_icon} ${branch_name} ${branch_end}"
-        PS1="${prompt_user}${prompt_symbol}${prompt_path}${prompt_branch} "
+        PS1="${prompt_time}${prompt_user}${prompt_symbol}${prompt_path}${prompt_branch} "
         return
     fi
 
-    PS1="${prompt_user}${prompt_symbol}${prompt_path} "
+    PS1="${prompt_time}${prompt_user}${prompt_symbol}${prompt_path} "
 }
 
 PROMPT_COMMAND="fancygit_prompt_builder"

--- a/prompt_styles/fancy-double-line.sh
+++ b/prompt_styles/fancy-double-line.sh
@@ -21,9 +21,12 @@ fancygit_prompt_builder() {
     user_symbol_end="${none}${bold_none}${bg_none}${s_dark_gray_bgnone}"
     branch="${s_blue_bgwhite}${bg_white}${black}${bold}"
     branch_end="${bg_none}${none}${bold_none}${s_white}"
+    time="${white}${bg_dark_gray}${bold}"
+    time_end="${bold_none}${bg_none}"
     local venv=""
     local path_sign=""
     local prompt_user=""
+    local prompt_time=""
 
     # Building prompt
     if [ "$branch_status" != "" ]
@@ -64,6 +67,12 @@ fancygit_prompt_builder() {
         has_unpushed_commits=""
     fi
 
+    if fg_show_time
+    then
+      formatted_time=$(date +"${time_format}")
+      prompt_time="${time}[${formatted_time}] ${time_end}"
+    fi
+
     if fg_show_user_at_machine
     then
         user_at_host="${white}${bg_dark_gray}${bold}"
@@ -91,11 +100,11 @@ fancygit_prompt_builder() {
         branch_icon=$(fg_get_branch_icon)
         prompt_path="${path_git}${venv}${has_git_stash}${has_untracked_files}${has_changed_files}${has_added_files}${has_unpushed_commits} $path_sign ${path_end}"
         prompt_branch="${branch} ${branch_icon} ${branch_name} ${branch_end}"
-        PS1="${prompt_user}${prompt_path}${prompt_branch}${prompt_symbol} "
+        PS1="${prompt_time}${prompt_user}${prompt_path}${prompt_branch}${prompt_symbol} "
         return
     fi
 
-    PS1="${prompt_user}${prompt_path}${prompt_symbol} "
+    PS1="${prompt_time}${prompt_user}${prompt_path}${prompt_symbol} "
 }
 
 PROMPT_COMMAND="fancygit_prompt_builder"

--- a/prompt_styles/human-dark-single-line.sh
+++ b/prompt_styles/human-dark-single-line.sh
@@ -8,6 +8,7 @@
 . ~/.fancy-git/commands.sh
 
 fancygit_prompt_builder() {
+    . ~/.fancy-git/config.sh
     . ~/.fancy-git/modules/update-manager.sh
 
     check_for_update
@@ -32,6 +33,7 @@ fancygit_prompt_builder() {
     local where="\W"
     local venv=""
     local user_at_host=""
+    local prompt_time=""
 
     if fg_show_full_path
     then
@@ -50,12 +52,18 @@ fancygit_prompt_builder() {
         branch_name=" ${red}on${none} ${orange}$branch_name${none}"
     fi
 
+    if fg_show_time
+    then
+      formatted_time=$(date +"${time_format}")
+      prompt_time="[${formatted_time}] "
+    fi
+
     if fg_show_user_at_machine
     then
         user_at_host="${user} ${at} ${host} ${in} "
     fi
 
-    PS1="${bold}${venv}${user_at_host}$where$branch_name$(fg_branch_status 1) ${bold_none}\$ "
+    PS1="${bold}${venv}${prompt_time}${user_at_host}$where$branch_name$(fg_branch_status 1) ${bold_none}\$ "
 }
 
 PROMPT_COMMAND="fancygit_prompt_builder"

--- a/prompt_styles/human-dark.sh
+++ b/prompt_styles/human-dark.sh
@@ -8,6 +8,7 @@
 . ~/.fancy-git/commands.sh
 
 fancygit_prompt_builder() {
+    . ~/.fancy-git/config.sh
     . ~/.fancy-git/modules/update-manager.sh
 
     check_for_update
@@ -32,6 +33,7 @@ fancygit_prompt_builder() {
     local where="\W"
     local venv=""
     local user_at_host=""
+    local prompt_time=""
 
     if fg_show_full_path
     then
@@ -50,12 +52,18 @@ fancygit_prompt_builder() {
         branch_name="${on} ${orange}$branch_name${none}"
     fi
 
+    if fg_show_time
+    then
+      formatted_time=$(date +"${time_format}")
+      prompt_time="[${formatted_time}] "
+    fi
+
     if fg_show_user_at_machine
     then
         user_at_host="${user} ${at} ${host} ${in} "
     fi
 
-    PS1="${bold}${venv}${user_at_host}$where $branch_name$(fg_branch_status 1)${bold_none}\n\$ "
+    PS1="${bold}${venv}${prompt_time}${user_at_host}$where $branch_name$(fg_branch_status 1)${bold_none}\n\$ "
 }
 
 PROMPT_COMMAND="fancygit_prompt_builder"

--- a/prompt_styles/human-single-line.sh
+++ b/prompt_styles/human-single-line.sh
@@ -8,6 +8,7 @@
 . ~/.fancy-git/commands.sh
 
 fancygit_prompt_builder() {
+    . ~/.fancy-git/config.sh
     . ~/.fancy-git/modules/update-manager.sh
 
     check_for_update
@@ -29,6 +30,7 @@ fancygit_prompt_builder() {
     local where="${light_green}\w${none}"
     local venv=""
     local user_at_host=""
+    local prompt_time=""
 
     if ! fg_show_full_path
     then
@@ -47,12 +49,18 @@ fancygit_prompt_builder() {
         branch_name=" on ${light_magenta}$branch_name${none}"
     fi
 
+    if fg_show_time
+    then
+      formatted_time=$(date +"${time_format}")
+      prompt_time="[${formatted_time}] "
+    fi
+
     if fg_show_user_at_machine
     then
         user_at_host="${user} at ${host} in "
     fi
 
-    PS1="${bold}${venv}${user_at_host}$where$branch_name$(fg_branch_status 1) ${bold_none}\$ "
+    PS1="${bold}${venv}${prompt_time}${user_at_host}$where$branch_name$(fg_branch_status 1) ${bold_none}\$ "
 }
 
 PROMPT_COMMAND="fancygit_prompt_builder"

--- a/prompt_styles/human.sh
+++ b/prompt_styles/human.sh
@@ -8,6 +8,7 @@
 . ~/.fancy-git/commands.sh
 
 fancygit_prompt_builder() {
+    . ~/.fancy-git/config.sh
     . ~/.fancy-git/modules/update-manager.sh
 
     check_for_update
@@ -29,6 +30,7 @@ fancygit_prompt_builder() {
     local where="${light_green}\w${none}"
     local venv=""
     local user_at_host=""
+    local prompt_time=""
 
     if ! fg_show_full_path
     then
@@ -47,12 +49,18 @@ fancygit_prompt_builder() {
         branch_name="on ${light_magenta}$branch_name${none}"
     fi
 
+    if fg_show_time
+    then
+      formatted_time=$(date +"${time_format}")
+      prompt_time="[${formatted_time}] "
+    fi
+
     if fg_show_user_at_machine
     then
         user_at_host="${user} at ${host} in "
     fi
 
-    PS1="${bold}${venv}${user_at_host}$where $branch_name$(fg_branch_status 1)${bold_none}\n\$ "
+    PS1="${bold}${venv}${prompt_time}${user_at_host}$where $branch_name$(fg_branch_status 1)${bold_none}\n\$ "
 }
 
 PROMPT_COMMAND="fancygit_prompt_builder"

--- a/prompt_styles/light-double-line.sh
+++ b/prompt_styles/light-double-line.sh
@@ -24,6 +24,7 @@ fancygit_prompt_builder() {
     local venv=""
     local path_sign=""
     local prompt_user=""
+    local prompt_time=""
 
     # Building prompt
     if [ "$branch_status" != "" ]
@@ -64,6 +65,14 @@ fancygit_prompt_builder() {
         has_unpushed_commits=""
     fi
 
+    if fg_show_time
+    then
+      time="${black}${bg_white}${bold}"
+      time_end="${bold_none}${bg_none}"
+      formatted_time=$(date +"${time_format}")
+      prompt_time="${time}[${formatted_time}] ${time_end}"
+    fi
+
     if fg_show_user_at_machine
     then
         user_at_host="${black}${bg_white}${bold}"
@@ -91,11 +100,11 @@ fancygit_prompt_builder() {
         branch_icon=$(fg_get_branch_icon)
         prompt_path="${path_git}${venv}${has_git_stash}${has_untracked_files}${has_changed_files}${has_added_files}${has_unpushed_commits} $path_sign ${path_end}"
         prompt_branch="${branch} ${branch_icon} ${branch_name} ${branch_end}"
-        PS1="${prompt_user}${prompt_path}${prompt_branch}${prompt_symbol} "
+        PS1="${prompt_time}${prompt_user}${prompt_path}${prompt_branch}${prompt_symbol} "
         return
     fi
 
-    PS1="${prompt_user}${prompt_path}${prompt_symbol} "
+    PS1="${prompt_time}${prompt_user}${prompt_path}${prompt_symbol} "
 }
 
 PROMPT_COMMAND="fancygit_prompt_builder"

--- a/prompt_styles/light.sh
+++ b/prompt_styles/light.sh
@@ -23,9 +23,12 @@ fancygit_prompt_builder() {
     path_end="${none}${bold_none}"
     branch="${s_lightgray_bgwhite}${bg_white}${black}${bold}"
     branch_end="${bg_none}${none}${bold_none}${s_white}"
+    time="${black}${bg_light_gray}${bold}"
+    time_end="${bold_none}${bg_none}"
     local venv=""
     local path_sign=""
     local prompt_user=""
+    local prompt_time=""
 
     # Building prompt
     if [ "$branch_status" != "" ]
@@ -66,6 +69,12 @@ fancygit_prompt_builder() {
         has_unpushed_commits=""
     fi
 
+    if fg_show_time
+    then
+      formatted_time=$(date +"${time_format}")
+      prompt_time="${time}[${formatted_time}] ${time_end}"
+    fi
+
     if fg_show_user_at_machine
     then
         prompt_user="${user_at_host}\\u@\\h ${user_at_host_end}"
@@ -91,11 +100,11 @@ fancygit_prompt_builder() {
         branch_icon=$(fg_get_branch_icon)
         prompt_path="${path_git}${venv}${has_git_stash}${has_untracked_files}${has_changed_files}${has_added_files}${has_unpushed_commits} $path_sign ${path_end}"
         prompt_branch="${branch} ${branch_icon} ${branch_name} ${branch_end}"
-        PS1="${prompt_user}${prompt_symbol}${prompt_path}${prompt_branch} "
+        PS1="$prompt_time${prompt_user}${prompt_symbol}${prompt_path}${prompt_branch} "
         return
     fi
 
-    PS1="${prompt_user}${prompt_symbol}${prompt_path} "
+    PS1="${prompt_time}${prompt_user}${prompt_symbol}${prompt_path} "
 }
 
 PROMPT_COMMAND="fancygit_prompt_builder"

--- a/prompt_styles/simple-double-line.sh
+++ b/prompt_styles/simple-double-line.sh
@@ -35,6 +35,7 @@ fancygit_prompt_builder() {
     local where="${blue}\w${none}"
     local venv=""
     local user_at_host=""
+    local prompt_time=""
 
     if ! fg_show_full_path
     then
@@ -49,12 +50,18 @@ fancygit_prompt_builder() {
         venv="(`basename \"$CONDA_DEFAULT_ENV\"`) "
     fi
 
+    if fg_show_time
+    then
+      formatted_time=$(date +"${time_format}")
+      prompt_time="${light_green}[${formatted_time}] "
+    fi
+
     if fg_show_user_at_machine
     then
         user_at_host="$user$at$host:"
     fi
 
-    PS1="${bold}${venv}${user_at_host}$where$(fg_branch_name)${bold_none}\n\$ "
+    PS1="${bold}${venv}${prompt_time}${user_at_host}$where$(fg_branch_name)${bold_none}\n\$ "
 }
 
 PROMPT_COMMAND="fancygit_prompt_builder"

--- a/prompt_styles/simple.sh
+++ b/prompt_styles/simple.sh
@@ -35,6 +35,7 @@ fancygit_prompt_builder() {
     local where
     local venv=""
     local user_at_host=""
+    local prompt_time=""
 
     user="${light_green}\u${none}"
     at="${none}@${none}"
@@ -54,12 +55,18 @@ fancygit_prompt_builder() {
         venv="(`basename \"$CONDA_DEFAULT_ENV\"`) "
     fi
 
+    if fg_show_time
+    then
+      formatted_time=$(date +"${time_format}")
+      prompt_time="${light_green}[${formatted_time}] "
+    fi
+
     if fg_show_user_at_machine
     then
         user_at_host="$user$at$host:"
     fi
 
-    PS1="${bold}${venv}${user_at_host}$where\$$(fg_branch_name)${bold_none} "
+    PS1="${bold}${venv}${prompt_time}${user_at_host}$where\$$(fg_branch_name)${bold_none} "
 }
 
 PROMPT_COMMAND="fancygit_prompt_builder"


### PR DESCRIPTION
This PR ads additional prompt for current time in front of prompt for user@host which is configurable meaning it can be turned on/off by your preference (by setting `show-time` to either `true` or `false`). It is applied to all themes available. The prompt for current time has same stylish settings as prompt for user@host in every theme and I added square brackets as wrapper around time (like: `[20:21:12]`, check the screenshots below). Additionally, user can configure his preferred format of showing time by setting value for key `time_format` in `config.sh` file. Default time format is: `%H:%M:%S` but it can be overriden in `config-override.sh` file.

Under the hood it uses `date` shell command which is installed on most unix/linux distributions and macos by default.

The other idea could be that we have predefined time formats in `config.sh` for example:

```
//config.sh
local hour_minute_second_format

hour_minute_second_format=%H:%M:%S
```

and in `app_config` you could reference certain time format by descriptive variable name from `config.sh` like `time-format:hour_minute_second_format` but there are so many ways of formatting time and I am not sure is it really worth of listing them all. I would rather let user to define it's own time format in `config-override` which will override defaulted `time_format` in `config.sh`

### Examples of added prompt time for available themes:

#### default:

![image](https://user-images.githubusercontent.com/2964787/117947021-19491280-b310-11eb-8313-4a68832391a1.png)

#### dark:

![image](https://user-images.githubusercontent.com/2964787/117947289-59a89080-b310-11eb-9c5e-1f75d18daec9.png)

#### dark-col-double-line:

![image](https://user-images.githubusercontent.com/2964787/117947410-747b0500-b310-11eb-94b4-ba740aded5e3.png)

#### dark-double-line:

![image](https://user-images.githubusercontent.com/2964787/117947663-b7d57380-b310-11eb-888e-e76150825e21.png)

#### fancy-double-line:

![image](https://user-images.githubusercontent.com/2964787/117947794-d176bb00-b310-11eb-938b-1ab894f397ee.png)

#### human:

![image](https://user-images.githubusercontent.com/2964787/117947883-e6534e80-b310-11eb-878a-a1c168ee8683.png)

#### human-dark:

![image](https://user-images.githubusercontent.com/2964787/117947961-fa974b80-b310-11eb-8855-16f17f776e37.png)

#### human-dark-single-line:

![image](https://user-images.githubusercontent.com/2964787/117948086-17338380-b311-11eb-9819-efc53905a7b5.png)

#### human-single-line:

![image](https://user-images.githubusercontent.com/2964787/117948166-287c9000-b311-11eb-8a51-9a481fbba182.png)

#### light:

![image](https://user-images.githubusercontent.com/2964787/117948301-4ba73f80-b311-11eb-98b4-3570665654e1.png)

#### light-double-line:

![image](https://user-images.githubusercontent.com/2964787/117948383-61b50000-b311-11eb-9ce3-c8b8d2fc6b8e.png)

#### simple:

![image](https://user-images.githubusercontent.com/2964787/117948538-814c2880-b311-11eb-948f-1c5366004313.png)

#### simple-double-line:

![image](https://user-images.githubusercontent.com/2964787/117948630-9b860680-b311-11eb-9716-4ef10f48c217.png)

