### PR TITLE
Add stderr support

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -5,14 +5,16 @@
 #
 # Fancygit installation script.
 
+errcho() { >&2 echo $@; }
+
 fg_os=$(uname)
 
 git_path=`whereis git | cut -d ":" -f 2`
 
 if [ "$git_path" = "" ]; then
-    echo ""
-    echo " ⚠ Please install git before running this command."
-    echo ""
+    errcho ""
+    errcho " ⚠ Please install git before running this command."
+    errcho ""
     exit 0
 fi
 


### PR DESCRIPTION
- Add a function for echoing to `stderr`
- Change error message to use the `errcho` function rather than `echo`

Will still show error message in the terminal, but it will be `stderr`, as errors should be