### PR TITLE
Amend installation script to check fontcache is installed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 > Any trouble, please visit the [troubleshooting page](https://github.com/diogocavilha/fancy-git/blob/master/TROUBLESHOOTING.md)
 
+## v7.1.8
+- Update installed to check fontconfig is installed prior to running script
+
 ## v7.1.7
 
 - Fix double line for default theme.

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ curl -sS https://raw.githubusercontent.com/diogocavilha/fancy-git/master/uninsta
 
 # :heavy_check_mark: After installing
 
-1. Change your terminal font to one of these fonts:  
+1. Change the font *in your terminal application* to one of these fonts:  
    - **Sauce-Code-Pro-Nerd-Font-Complete-Windows-Compatible.ttf**.
    - **DejaVu-Sans-Mono-Nerd-Font-Complete.ttf**.
    - **DejaVu-Sans-Mono-Nerd-Font-Complete-Mono.ttf**.

--- a/install.sh
+++ b/install.sh
@@ -7,6 +7,7 @@
 
 FANCYGIT_RUNNING_OS=$(uname)
 FANCYGIT_GIT_PATH=$(whereis git | cut -d ":" -f 2)
+FANCYGIT_FONTCONFIG_PATH=$(dpkg-query -l fontconfig 2>&1)   #redirect STDERR to STDOUT to capture output
 
 errcho() {
     >&2 echo "$@";
@@ -15,6 +16,13 @@ errcho() {
 if [ "" = "$FANCYGIT_GIT_PATH" ]; then
     errcho ""
     errcho " ⚠ Please install git before running this command."
+    errcho ""
+    exit 0
+fi
+
+if [ "dpkg-query: no packages found matching fontconfig" = "$FANCYGIT_FONTCONFIG_PATH" ]; then
+    errcho ""
+    errcho " ⚠ Please install fontconfig before running this command."
     errcho ""
     exit 0
 fi

--- a/version.sh
+++ b/version.sh
@@ -3,4 +3,4 @@
 # Author: Diogo Alexsander Cavilha <diogocavilha@gmail.com>
 # Date:   11.17.2017
 
-export FANCYGIT_VERSION="7.1.7"
+export FANCYGIT_VERSION="7.1.8"


### PR DESCRIPTION
I went to install fancy-git for the first time but noticed an error message at the end: `fc-cache: command not found`

I realised this was because I didn't have fontconfig installed.

The existing install checks for the presence of git, but not for fontconfig.  I tried using `whereis` but found on my Debian 11 installation there was a font config folder at `/usr/share/fontconfig` so that didn't help.  I then tried using a `which` command instead but found that even after installation was successfully completed via `sudo apt install fontconfig` it still returned an empty string. I therefore switch to use the `dpkg` command instead as this returned an error if not installed. I'm not sure if there is a better way to check but running this modified script on a machine without fontconfig installed correctly errors out and if fontconfig is installed it then correctly installs.