### PR TITLE
--nofontconfig option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 > Any trouble, please visit the [troubleshooting page](https://github.com/diogocavilha/fancy-git/blob/master/TROUBLESHOOTING.md)
 
+## v7.1.9
+- Add --nofontconfig option to install.sh to skip creation of ~/.fonts and requirement for fontconfig to be installed (useful option for those only accessing a headless server via SSH where the font needs to be set on their local terminal application)
+
 ## v7.1.8
 - Update installed to check fontconfig is installed prior to running script
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ curl -sS https://raw.githubusercontent.com/diogocavilha/fancy-git/master/uninsta
    - **JetBrains-Mono-Medium-Nerd-Font-Complete-Mono.ttf**.  
    It's necessary for rendering icons/symbols properly.  
    If you can't find the font, it's still possible to install it manually by running `fancygit --fonts-install` or even installing the ttf file which is placed at `~/.fancy-git/fonts/`.
+   NB for Windows Terminal only the Sauce Code option above will display git icons correctly.
 2. Restart your terminal.
 
 Run `fancygit -h` to check FancyGit help.

--- a/install.sh
+++ b/install.sh
@@ -20,11 +20,17 @@ if [ "" = "$FANCYGIT_GIT_PATH" ]; then
     exit 0
 fi
 
-if [ "dpkg-query: no packages found matching fontconfig" = "$FANCYGIT_FONTCONFIG_PATH" ]; then
-    errcho ""
-    errcho " ⚠ Please install fontconfig before running this command."
-    errcho ""
-    exit 0
+if [ "--nofontconfig" = "$1" ]; then
+    echo "--nofontconfig selected: skipping fontconfig check"
+else
+    if [ "dpkg-query: no packages found matching fontconfig" = "$FANCYGIT_FONTCONFIG_PATH" ]; then
+        errcho ""
+        errcho " ⚠ Please either install fontconfig before running this command"
+        errcho "   or use the --nofontconfig option to install fancygit"
+        errcho "   without fontconfig present - e.g., if only using SSH"
+        errcho ""
+        exit 0
+    fi
 fi
 
 git clone https://github.com/diogocavilha/fancy-git.git ~/.fancy-git
@@ -51,11 +57,15 @@ if [ "Darwin" = "$FANCYGIT_RUNNING_OS" ]; then
     cat ~/.fancy-git/app_config_sample > ~/.fancy-git/app_config
 fi
 
-mkdir -p ~/.fonts
-cp -i ~/.fancy-git/fonts/SourceCodePro+Powerline+Awesome+Regular.ttf ~/.fonts
-cp -i ~/.fancy-git/fonts/Sauce-Code-Pro-Nerd-Font-Complete-Windows-Compatible.ttf ~/.fonts
-cp -i ~/.fancy-git/fonts/DejaVu-Sans-Mono-Nerd-Font-Complete.ttf ~/.fonts
-cp -i ~/.fancy-git/fonts/DejaVu-Sans-Mono-Nerd-Font-Complete-Mono.ttf ~/.fonts
-cp -i ~/.fancy-git/fonts/JetBrains-Mono-Regular-Nerd-Font-Complete-Mono.ttf ~/.fonts
-cp -i ~/.fancy-git/fonts/JetBrains-Mono-Medium-Nerd-Font-Complete-Mono.ttf ~/.fonts
-fc-cache -fv
+if [ "--nofontconfig" = "$1" ]; then
+    echo "--nofontconfig selected: skipping font installation"
+else
+    mkdir -p ~/.fonts
+    cp -i ~/.fancy-git/fonts/SourceCodePro+Powerline+Awesome+Regular.ttf ~/.fonts
+    cp -i ~/.fancy-git/fonts/Sauce-Code-Pro-Nerd-Font-Complete-Windows-Compatible.ttf ~/.fonts
+    cp -i ~/.fancy-git/fonts/DejaVu-Sans-Mono-Nerd-Font-Complete.ttf ~/.fonts
+    cp -i ~/.fancy-git/fonts/DejaVu-Sans-Mono-Nerd-Font-Complete-Mono.ttf ~/.fonts
+    cp -i ~/.fancy-git/fonts/JetBrains-Mono-Regular-Nerd-Font-Complete-Mono.ttf ~/.fonts
+    cp -i ~/.fancy-git/fonts/JetBrains-Mono-Medium-Nerd-Font-Complete-Mono.ttf ~/.fonts
+    fc-cache -fv
+fi


### PR DESCRIPTION
As mentioned in #121 I realised after adding the check for fontconfig that actually on headless machines (e.g. Linode, Digital Ocean, etc.) only being accessed via a local terminal app there was no need to create a `~/.fonts` directory or to require fontconfig to be installed - have therefore added a potential `--nofontconfig` switch to the install.sh script.  Users are notified of its presence if they try to run the script with git installed but without fontconfig.  If the switch is selected then it skips the last section of code in the script. Also added an earlier if statement so it doesn't keep stopping on the error re fontconfig being installed!

Obviously if I've misunderstood the requirements feel free to reject but AIUI these fonts are only required is using a terminal on the local machine.