### PR TITLE
:bug: Fix double space after branch name on human theme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 > Any trouble, please visit the [troubleshooting page](https://github.com/diogocavilha/fancy-git/blob/master/TROUBLESHOOTING.md)
 
+## v7.5.4
+- Fix double space after branch name when using human theme and double line mode is disabled.
+
 ## v7.5.3
 - Fix 4 stuck characters when navigating through history commands.
 - Fix prompt color leak for default theme.

--- a/theme-functions.sh
+++ b/theme-functions.sh
@@ -137,7 +137,7 @@ __fancygit_get_poor_notification_area() {
         # Trim notification_area content
         notification_area=$(echo "$notification_area" | sed -e 's/[[:space:]]*$//' | sed -e 's/^[[:space:]]*//')
 
-        echo "${notification_area//[[:space:]]*$/}"
+        echo " ${notification_area//[[:space:]]*$/}"
         return
     fi
 

--- a/themes/human.sh
+++ b/themes/human.sh
@@ -135,7 +135,7 @@ fancygit_theme_builder() {
     then
         prompt_path="${path_git}${path_sign}${path_end}"
         prompt_branch="${branch}${branch_name}${branch_end}"
-        PS1="${prompt_time}${prompt_user_at_host}${prompt_path}${venv_name}${preposition_color} on ${prompt_branch} $(fancygit_get_notification_area "$is_rich_notification")"
+        PS1="${prompt_time}${prompt_user_at_host}${prompt_path}${venv_name}${preposition_color} on ${prompt_branch}$(fancygit_get_notification_area "$is_rich_notification")"
         PS1="${bold_prompt}${PS1}${prompt_symbol}${is_double_line}${normal_prompt} "
         return
     fi

--- a/version.sh
+++ b/version.sh
@@ -3,4 +3,4 @@
 # Author: Diogo Alexsander Cavilha <diogocavilha@gmail.com>
 # Date:   11.17.2017
 
-export FANCYGIT_VERSION="7.5.3"
+export FANCYGIT_VERSION="7.5.4"


### PR DESCRIPTION
Fix double space after branch name when using human theme and double line mode is disabled.