### PR TITLE
:sparkles: add setting for clear in git aliases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 > Any trouble, please visit the [troubleshooting page](https://github.com/diogocavilha/fancy-git/blob/master/TROUBLESHOOTING.md)
 
+## v7.6.0
+- Add `fancygit --enable-git-clear` command to clear terminal on some Git aliases (ga, gaa, gck, gd, gs).
+- Add `fancygit --disable-git-clear` command to prevent clearing terminal on some Git aliases (ga, gaa, gck, gd, gs).
+
 ## v7.5.5
 - Add more icon overrides using the `FANCYGIT_ICON_GIT_REPO` and `FANCYGIT_ICON_VENV` environment variables.
 

--- a/README.md
+++ b/README.md
@@ -199,6 +199,8 @@ Type `fancygit -h` to see all available feature switchers on **"FEATURE SWITCHER
 | fancygit --unset-user-name                   | Restore the user name to default.
 | fancygit --set-host-name {name}              | Set the host name.
 | fancygit --unset-host-name                   | Restore the host name to default.
+| fancygit --enable-git-clear                  | Clear the terminal as part of some git aliases
+| fancygit --disable-git-clear                 | Do not clear the terminal with any git aliases
 | fancygit --separator-default                 | Change the separator to default style.
 | fancygit --separator-blocks                  | Change the separator to blocks style.
 | fancygit --separator-blocks-tiny             | Change the separator to blocks-tiny style.

--- a/alias_functions/ga.sh
+++ b/alias_functions/ga.sh
@@ -5,6 +5,11 @@
 #
 # git add
 
+. ~/.fancy-git/modules/settings-manager.sh
+git_use_clear=$(fancygit_config_get "git_use_clear" "true")
+
 git add "$*" && \
-clear && \
+if [ "$git_use_clear" = "true" ]; then \
+  clear; \
+fi && \
 git status

--- a/alias_functions/gck.sh
+++ b/alias_functions/gck.sh
@@ -5,6 +5,11 @@
 #
 # git checkout --
 
+. ~/.fancy-git/modules/settings-manager.sh
+git_use_clear=$(fancygit_config_get "git_use_clear" "true")
+
 git checkout -- "$*" && \
-clear && \
+if [ "$git_use_clear" = "true" ]; then \
+  clear; \
+fi && \
 git status

--- a/alias_functions/gd.sh
+++ b/alias_functions/gd.sh
@@ -5,12 +5,21 @@
 #
 # git diff
 
+. ~/.fancy-git/modules/settings-manager.sh
+git_use_clear=$(fancygit_config_get "git_use_clear" "true")
+
+clear_if_enabled () {
+    if [ "$git_use_clear" = "true" ]; then
+      clear
+    fi
+}
+
 # It's more like a return command. This is a Mac OS issue.
 fg_return() {
     exit
 }
 
-clear
+clear_if_enabled
 
 if [ "$1" = "" ]; then
     git diff
@@ -24,7 +33,7 @@ read -rp " Add this file to commit? [y/N]: " r
 
 if [ "$r" = "y" ]; then
     git add "$1"
-    clear
+    clear_if_enabled
     git status
     fg_return
 fi
@@ -35,5 +44,5 @@ if [ "$r" = "y" ]; then
     git checkout "$1"
 fi
 
-clear
+clear_if_enabled
 git status

--- a/alias_functions/gs.sh
+++ b/alias_functions/gs.sh
@@ -1,14 +1,13 @@
 #!/bin/bash
 #
-# Author: Diogo Alexsander Cavilha <diogocavilha@gmail.com>
-# Date:   03.13.2017
+# Author: Mike Szczys <szczys@hotmail.com>
+# Date:   06.02.2023
 #
-# git add --all
+# git status
 
 . ~/.fancy-git/modules/settings-manager.sh
 git_use_clear=$(fancygit_config_get "git_use_clear" "true")
 
-git add --all && \
 if [ "$git_use_clear" = "true" ]; then \
   clear; \
 fi && \

--- a/aliases
+++ b/aliases
@@ -1,5 +1,5 @@
 alias fancygit="sh ~/.fancy-git/commands-handler.sh $1"
-alias gs="clear && git status"
+alias gs="sh ~/.fancy-git/alias_functions/gs.sh"
 alias ga="sh ~/.fancy-git/alias_functions/ga.sh"
 alias gap="git add -p"
 alias gaa="sh ~/.fancy-git/alias_functions/gaa.sh"

--- a/commands-handler.sh
+++ b/commands-handler.sh
@@ -44,6 +44,8 @@ case "$1" in
     "--disable-host-name") fancygit_config_save "show_host_prompt" "false";;
     "--enable-user-symbol") fancygit_config_save "show_user_symbol_prompt" "true";;
     "--disable-user-symbol") fancygit_config_save "show_user_symbol_prompt" "false";;
+    "--enable-git-clear") fancygit_config_save "git_use_clear" "true";;
+    "--disable-git-clear") fancygit_config_save "git_use_clear" "false";;
 
     # Set Name and Host.
     "--set-user-name") fancygit_config_save "user_name" "$2";;

--- a/fancygit-completion
+++ b/fancygit-completion
@@ -31,6 +31,8 @@ _fancygit() {
         --disable-host-name \
         --enable-user-symbol \
         --disable-user-symbol \
+        --enable-git-clear \
+        --disable-git-clear \
         --set-user-name \
         --unset-user-name \
         --set-host-name \

--- a/help.sh
+++ b/help.sh
@@ -37,6 +37,8 @@ FEATURE SWITCHER COMMANDS:
    fancygit --disable-bold-prompt                 Show regular prompt font.
    fancygit --enable-host-name                    Show host name. (It works for human theme only)
    fancygit --disable-host-name                   Hide host name. (It works for human theme only)
+   fancygit --enable-git-clear                    Clear the terminal as part of some git aliases
+   fancygit --disable-git-clear                   Do not clear the terminal with any git aliases
 
 THEME COMMANDS:
    fancygit --theme-default                       Change prompt to the default theme.

--- a/version.sh
+++ b/version.sh
@@ -3,4 +3,4 @@
 # Author: Diogo Alexsander Cavilha <diogocavilha@gmail.com>
 # Date:   11.17.2017
 
-export FANCYGIT_VERSION="7.5.5"
+export FANCYGIT_VERSION="7.6.0"


### PR DESCRIPTION
Some of the git aliases (ga, gaa, gck, gd, gs) clear the terminal as part of the operation. This means terminal scrollback is lost which is undesirable for some users. This commit adds a setting to toggle the behavior.