### PR TITLE
Add missing icon overrides for git and venv

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 > Any trouble, please visit the [troubleshooting page](https://github.com/diogocavilha/fancy-git/blob/master/TROUBLESHOOTING.md)
 
+## v7.5.5
+- Add more icon overrides using the `FANCYGIT_ICON_GIT_REPO` and `FANCYGIT_ICON_VENV` environment variables.
+
 ## v7.5.4
 - Fix double space after branch name when using human theme and double line mode is disabled.
 

--- a/README.md
+++ b/README.md
@@ -266,6 +266,9 @@ FANCYGIT_ICON_LOCAL_REMOTE_BRANCH=""
 Here you can see a list of available environment variables FancyGit will search and replace:
 
 ```sh
+# Path is a git repository
+FANCYGIT_ICON_GIT_REPO
+
 # Only local branch icon.
 FANCYGIT_ICON_LOCAL_BRANCH
 
@@ -289,6 +292,9 @@ FANCYGIT_ICON_HAS_ADDED_FILES
 
 # Unpushed commits.
 FANCYGIT_ICON_HAS_UNPUSHED_COMMITS
+
+# Path is a python virtual environment
+FANCYGIT_ICON_VENV
 ```
 
 # Contributors ✨

--- a/theme-functions.sh
+++ b/theme-functions.sh
@@ -162,7 +162,7 @@ __has_conda_env() {
 __fancygit_get_venv_icon() {
     local icon_venv
 
-    icon_venv=" "
+    icon_venv=" ${FANCYGIT_ICON_VENV:-}"
 
     if [[ -n $VIRTUAL_ENV ]] || __has_conda_env
     then

--- a/themes/default.sh
+++ b/themes/default.sh
@@ -63,7 +63,7 @@ fancygit_theme_builder() {
     local separator
     separator=$(fancygit_config_get "separator" "")
 
-    local icon_git_repo=""
+    local icon_git_repo="${FANCYGIT_ICON_GIT_REPO:-}"
     local user="${user_color_font_tag}"
     local at="${at_color_font_tag}"
     local host="${host_color_font_tag}"

--- a/version.sh
+++ b/version.sh
@@ -3,4 +3,4 @@
 # Author: Diogo Alexsander Cavilha <diogocavilha@gmail.com>
 # Date:   11.17.2017
 
-export FANCYGIT_VERSION="7.5.4"
+export FANCYGIT_VERSION="7.5.5"


### PR DESCRIPTION
While trying fancy-git with different fonts, I wanted to change the icons used with the various `FANCYGIT_ICON_*` environment variables. Thereby, I noticed that there were two icons which cannot currently be overwritten this way.

Here's my pull request to fix that ;)