### PR TITLE
trim whitespace from 'wc -l' output to condense prompt

### DIFF
--- a/theme-functions.sh
+++ b/theme-functions.sh
@@ -54,7 +54,7 @@ __fancygit_get_rich_notification_area() {
         icon_changed_files=""
     fi
 
-    number_unpushed_commits=$(fancygit_git_get_unpushed_commits | wc -l)
+    number_unpushed_commits=$(fancygit_git_get_unpushed_commits | wc -l | xargs)
     icon_unpushed_commits="${icon_unpushed_commits}+${number_unpushed_commits}"
     if [ 0 -eq "$number_unpushed_commits" ]
     then


### PR DESCRIPTION
Not doing this caused my notification area to be awkwardly long. I looked for the canonical way to trim whitespace and found that people recommended [xargs](https://stackoverflow.com/a/12973694), which is odd but worked for me. I figured I'd contribute this patch upstream for others.