### PR TITLE
Make the PROMPT_COMMAND chain with existing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 > Any trouble, please visit the [troubleshooting page](https://github.com/diogocavilha/fancy-git/blob/master/TROUBLESHOOTING.md)
 
+## v7.7.0
+- Stop it overriding the existing `PROMPT_COMMAND` environment variable.
+
 ## v7.6.1
 - Fix shellcheck issues.
 

--- a/themes/default.sh
+++ b/themes/default.sh
@@ -161,4 +161,4 @@ fancygit_theme_builder() {
 
 # Here's where the magic happens!
 # It calls our main function (fancygit_theme_builder) in order to mount a beautiful PS1 prompt =D
-PROMPT_COMMAND="fancygit_theme_builder"
+PROMPT_COMMAND="fancygit_theme_builder;$PROMPT_COMMAND"

--- a/themes/human.sh
+++ b/themes/human.sh
@@ -145,4 +145,4 @@ fancygit_theme_builder() {
 
 # Here's where the magic happens!
 # It calls our main function (fancygit_theme_builder) in order to mount a beautiful PS1 prompt =D
-PROMPT_COMMAND="fancygit_theme_builder"
+PROMPT_COMMAND="fancygit_theme_builder;$PROMPT_COMMAND"

--- a/themes/simple.sh
+++ b/themes/simple.sh
@@ -117,4 +117,4 @@ __fancygit_theme_get_branch_area() {
 
 # Here's where the magic happens!
 # It calls our main function (fancygit_theme_builder) in order to mount a beautiful PS1 prompt =D
-PROMPT_COMMAND="fancygit_theme_builder"
+PROMPT_COMMAND="fancygit_theme_builder;$PROMPT_COMMAND"

--- a/version.sh
+++ b/version.sh
@@ -3,4 +3,4 @@
 # Author: Diogo Alexsander Cavilha <diogocavilha@gmail.com>
 # Date:   11.17.2017
 
-export FANCYGIT_VERSION="7.6.1"
+export FANCYGIT_VERSION="7.7.0"


### PR DESCRIPTION
If something else has already set the PROMPT_COMMAND (for example, ghostty or mise), currently the themes will clobber the existing value, breaking their functionality.

This patch adds `;$PROMPT_COMMAND` to the end, so that bash will execute the existing commands as well.